### PR TITLE
Added sys functionality to Micropython Interpreter

### DIFF
--- a/examples/cpp_torch_examples/Makefile
+++ b/examples/cpp_torch_examples/Makefile
@@ -1,0 +1,20 @@
+MPTOP = ../../micropython
+ITOP = ../../interpreter-manager
+LIBP = ../../lib
+CC = gcc
+CXX = g++
+CPPFLAGS = -I. -I$(MPTOP) -I$(ITOP) -I$(MPTOP)/ports/unix -I./build/ -I./build/genhdr -lstdc++ -fpermissive -g -DNO_QSTR
+LDFLAGS = -L. -fpermissive
+
+hello-embed: -lmicropython hello-embed.o $(ITOP)/interpreterManager.o
+
+hello-embed.o: -lmicropython __main.o
+
+__main.o: -lmicropython
+
+
+-lmicropython:
+	$(MAKE) -f ./Makefile.upylib MPTOP=$(MPTOP)
+
+clean:
+	rm -rf *.o *.a build ./lib hello-embed examples $(ITOP)/*.o $(LIBP)/*.o

--- a/examples/cpp_torch_examples/Makefile.upylib
+++ b/examples/cpp_torch_examples/Makefile.upylib
@@ -1,0 +1,192 @@
+MPTOP = ../..
+-include mpconfigport.mk
+include $(MPTOP)/py/mkenv.mk
+
+all: lib
+
+# OS name, for simple autoconfig
+UNAME_S := $(shell uname -s)
+
+# include py core make definitions
+include $(MPTOP)/py/py.mk
+
+INC +=  -I.
+INC +=  -I..
+INC +=  -I$(MPTOP)
+INC +=  -I$(MPTOP)/ports/unix
+INC += -I$(BUILD)
+
+# compiler settings
+CWARN = -Wall -Werror
+CWARN += -Wpointer-arith -Wuninitialized
+CFLAGS = $(INC) $(CWARN) -std=gnu99 -DUNIX $(CFLAGS_MOD) $(COPT) $(CFLAGS_EXTRA)
+
+# Debugging/Optimization
+ifdef DEBUG
+CFLAGS += -g
+COPT = -O0
+else
+COPT = -Os #-DNDEBUG
+# _FORTIFY_SOURCE is a feature in gcc/glibc which is intended to provide extra
+# security for detecting buffer overflows. Some distros (Ubuntu at the very least)
+# have it enabled by default.
+#
+# gcc already optimizes some printf calls to call puts and/or putchar. When
+# _FORTIFY_SOURCE is enabled and compiling with -O1 or greater, then some
+# printf calls will also be optimized to call __printf_chk (in glibc). Any
+# printfs which get redirected to __printf_chk are then no longer synchronized
+# with printfs that go through mp_printf.
+#
+# In MicroPython, we don't want to use the runtime library's printf but rather
+# go through mp_printf, so that stdout is properly tied into streams, etc.
+# This means that we either need to turn off _FORTIFY_SOURCE or provide our
+# own implementation of __printf_chk. We've chosen to turn off _FORTIFY_SOURCE.
+# It should also be noted that the use of printf in MicroPython is typically
+# quite limited anyways (primarily for debug and some error reporting, etc
+# in the unix version).
+#
+# Information about _FORTIFY_SOURCE seems to be rather scarce. The best I could
+# find was this: https://securityblog.redhat.com/2014/03/26/fortify-and-you/
+# Original patchset was introduced by
+# https://gcc.gnu.org/ml/gcc-patches/2004-09/msg02055.html .
+#
+# Turning off _FORTIFY_SOURCE is only required when compiling with -O1 or greater
+CFLAGS += -U _FORTIFY_SOURCE
+endif
+
+# On OSX, 'gcc' is a symlink to clang unless a real gcc is installed.
+# The unix port of MicroPython on OSX must be compiled with clang,
+# while cross-compile ports require gcc, so we test here for OSX and
+# if necessary override the value of 'CC' set in py/mkenv.mk
+ifeq ($(UNAME_S),Darwin)
+CC = clang
+# Use clang syntax for map file
+LDFLAGS_ARCH = -Wl,-map,$@.map
+else
+# Use gcc syntax for map file
+LDFLAGS_ARCH = -Wl,-Map=$@.map,--cref
+endif
+LDFLAGS = $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
+
+ifeq ($(MICROPY_FORCE_32BIT),1)
+# Note: you may need to install i386 versions of dependency packages,
+# starting with linux-libc-dev:i386
+ifeq ($(MICROPY_PY_FFI),1)
+ifeq ($(UNAME_S),Linux)
+CFLAGS_MOD += -I/usr/include/i686-linux-gnu
+endif
+endif
+endif
+
+ifeq ($(MICROPY_USE_READLINE),1)
+INC +=  -I$(MPTOP)/lib/mp-readline
+CFLAGS_MOD += -DMICROPY_USE_READLINE=1
+LIB_SRC_C_EXTRA += mp-readline/readline.c
+endif
+ifeq ($(MICROPY_USE_READLINE),2)
+CFLAGS_MOD += -DMICROPY_USE_READLINE=2
+LDFLAGS_MOD += -lreadline
+# the following is needed for BSD
+#LDFLAGS_MOD += -ltermcap
+endif
+ifeq ($(MICROPY_PY_TIME),1)
+CFLAGS_MOD += -DMICROPY_PY_TIME=1
+SRC_MOD += modtime.c
+endif
+ifeq ($(MICROPY_PY_TERMIOS),1)
+CFLAGS_MOD += -DMICROPY_PY_TERMIOS=1
+SRC_MOD += modtermios.c
+endif
+ifeq ($(MICROPY_PY_SOCKET),1)
+CFLAGS_MOD += -DMICROPY_PY_SOCKET=1
+SRC_MOD += modsocket.c
+endif
+
+ifeq ($(MICROPY_PY_FFI),1)
+
+ifeq ($(MICROPY_STANDALONE),1)
+LIBFFI_CFLAGS_MOD := -I$(shell ls -1d $(MPTOP)/lib/libffi/build_dir/out/lib/libffi-*/include)
+ ifeq ($(MICROPY_FORCE_32BIT),1)
+  LIBFFI_LDFLAGS_MOD = $(MPTOP)/lib/libffi/build_dir/out/lib32/libffi.a
+ else
+  LIBFFI_LDFLAGS_MOD = $(MPTOP)/lib/libffi/build_dir/out/lib/libffi.a
+ endif
+else
+LIBFFI_CFLAGS_MOD := $(shell pkg-config --cflags libffi)
+LIBFFI_LDFLAGS_MOD := $(shell pkg-config --libs libffi)
+endif
+
+ifeq ($(UNAME_S),Linux)
+LIBFFI_LDFLAGS_MOD += -ldl
+endif
+
+CFLAGS_MOD += $(LIBFFI_CFLAGS_MOD) -DMICROPY_PY_FFI=1
+LDFLAGS_MOD += $(LIBFFI_LDFLAGS_MOD)
+SRC_MOD += modffi.c
+endif
+
+
+#ADN_UTILITY = ../../lib/utility-micropython.c
+ADN_UTILITY = ../lib/__main.c
+# source files
+SRC_C = $(addprefix ports/unix/,\
+	gccollect.c \
+	unix_mphal.c \
+	input.c \
+	modmachine.c \
+	modos.c \
+	moduselect.c \
+	alloc.c \
+	coverage.c \
+	fatfs_port.c \
+	$(SRC_MOD) \
+	)
+
+SRC_C += $(ADN_UTILITY)
+
+LIB_SRC_C = $(addprefix lib/,\
+	$(LIB_SRC_C_EXTRA) \
+	utils/printf.c \
+	timeutils/timeutils.c \
+	)
+
+OBJ = $(PY_O)
+OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+OBJ += $(addprefix $(BUILD)/, $(LIB_SRC_C:.c=.o))
+
+# List of sources for qstr extraction
+SRC_QSTR += $(SRC_C) $(LIB_SRC_C)
+# Append any auto-generated sources that are needed by sources listed in
+# SRC_QSTR
+SRC_QSTR_AUTO_DEPS +=
+
+include $(MPTOP)/py/mkrules.mk
+
+# Value of configure's --host= option (required for cross-compilation).
+# Deduce it from CROSS_COMPILE by default, but can be overridden.
+ifneq ($(CROSS_COMPILE),)
+CROSS_COMPILE_HOST = --host=$(patsubst %-,%,$(CROSS_COMPILE))
+else
+CROSS_COMPILE_HOST =
+endif
+
+deplibs: libffi axtls
+
+# install-exec-recursive & install-data-am targets are used to avoid building
+# docs and depending on makeinfo
+libffi:
+	cd $(MPTOP)/lib/libffi; git clean -d -x -f
+	cd $(MPTOP)/lib/libffi; ./autogen.sh
+	mkdir -p $(MPTOP)/lib/libffi/build_dir; cd $(MPTOP)/lib/libffi/build_dir; \
+	../configure $(CROSS_COMPILE_HOST) --prefix=$$PWD/out CC="$(CC)" CXX="$(CXX)" LD="$(LD)"; \
+	make install-exec-recursive; make -C include install-data-am
+
+axtls: $(MPTOP)/lib/axtls/README
+	cd $(MPTOP)/lib/axtls; cp config/upyconfig config/.config
+	cd $(MPTOP)/lib/axtls; make oldconfig -B
+	cd $(MPTOP)/lib/axtls; make clean
+	cd $(MPTOP)/lib/axtls; make all CC="$(CC)" LD="$(LD)"
+
+$(MPTOP)/lib/axtls/README:
+	@echo "You cloned without --recursive, fetching submodules for you."
+	(cd $(MPTOP); git submodule update --init --recursive)

--- a/examples/cpp_torch_examples/hello-embed.cpp
+++ b/examples/cpp_torch_examples/hello-embed.cpp
@@ -1,0 +1,71 @@
+/*
+This file is an example embedding for the Interpreter Manager class
+*/
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "interpreterManager.h"
+
+
+extern "C" {
+    #include "py/compile.h"
+    #include "py/runtime.h"
+    #include "py/gc.h"
+    #include "py/stackctrl.h"
+
+    #include "py/builtin.h"
+    #include "py/repl.h"
+    #include "py/stackctrl.h"
+    #include "py/mphal.h"
+    #include "py/mpthread.h"
+    #include "extmod/misc.h"
+    #include "extmod/vfs.h"
+    #include "extmod/vfs_posix.h"
+    #include "input.h"
+    #include "py/objlist.h"
+
+
+    //#include "../../lib/__main.c"
+    int __main();
+
+}
+
+static char heap[16384];
+
+
+mp_obj_t execute_from_str(const char *str) {
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        qstr src_name = 1/*MP_QSTR_*/;
+        mp_lexer_t *lex = mp_lexer_new_from_str_len(src_name, str, strlen(str), false);
+        mp_parse_tree_t pt = mp_parse(lex, MP_PARSE_FILE_INPUT);
+        mp_obj_t module_fun = mp_compile(&pt, src_name, false);
+        mp_call_function_0(module_fun);
+        nlr_pop();
+        return 0;
+    } else {
+        // uncaught exception
+        return (mp_obj_t)nlr.ret_val;
+    }
+}
+
+
+int main() {
+
+    __main();
+
+    // Initialized stack limit
+    mp_stack_set_limit(40000 * (BYTES_PER_WORD / 4));
+    // Initialize heap
+    gc_init(heap, heap + sizeof(heap));
+    // Initialize interpreter
+    mp_init();
+
+    const char str[] = "import sys\nprint(sys.modules)";
+    if (execute_from_str(str)) {
+        printf("Error\n");
+        return -1;
+    }
+
+    return 0;
+}

--- a/examples/cpp_torch_examples/mpconfigport.h
+++ b/examples/cpp_torch_examples/mpconfigport.h
@@ -1,0 +1,1 @@
+#include "mpconfigport_minimal.h"

--- a/examples/cpp_torch_examples/mpconfigport_minimal.h
+++ b/examples/cpp_torch_examples/mpconfigport_minimal.h
@@ -1,0 +1,129 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// options to control how MicroPython is built
+
+#define MICROPY_ALLOC_PATH_MAX      (PATH_MAX)
+#define MICROPY_ENABLE_GC           (1)
+#define MICROPY_ENABLE_FINALISER    (0)
+#define MICROPY_STACK_CHECK         (0)
+#define MICROPY_COMP_CONST          (0)
+#define MICROPY_MEM_STATS           (0)
+#define MICROPY_DEBUG_PRINTERS      (0)
+#define MICROPY_READER_POSIX        (1)
+#define MICROPY_KBD_EXCEPTION       (1)
+#define MICROPY_HELPER_REPL         (1)
+#define MICROPY_HELPER_LEXER_UNIX   (1)
+#define MICROPY_ENABLE_SOURCE_LINE  (0)
+#define MICROPY_ERROR_REPORTING     (MICROPY_ERROR_REPORTING_TERSE)
+#define MICROPY_WARNINGS            (0)
+#define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF   (0)
+#define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_NONE)
+#define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_NONE)
+#define MICROPY_STREAMS_NON_BLOCK   (0)
+#define MICROPY_OPT_COMPUTED_GOTO   (0)
+#define MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE (0)
+#define MICROPY_CAN_OVERRIDE_BUILTINS (0)
+#define MICROPY_BUILTIN_METHOD_CHECK_SELF_ARG (0)
+#define MICROPY_CPYTHON_COMPAT      (0)
+#define MICROPY_PY_BUILTINS_BYTEARRAY (0)
+#define MICROPY_PY_BUILTINS_MEMORYVIEW (0)
+#define MICROPY_PY_BUILTINS_COMPILE (0)
+#define MICROPY_PY_BUILTINS_ENUMERATE (0)
+#define MICROPY_PY_BUILTINS_FILTER  (0)
+#define MICROPY_PY_BUILTINS_FROZENSET (0)
+#define MICROPY_PY_BUILTINS_REVERSED (0)
+#define MICROPY_PY_BUILTINS_SET     (0)
+#define MICROPY_PY_BUILTINS_SLICE   (0)
+#define MICROPY_PY_BUILTINS_STR_UNICODE (0)
+#define MICROPY_PY_BUILTINS_PROPERTY (0)
+#define MICROPY_PY_BUILTINS_MIN_MAX (0)
+#define MICROPY_PY___FILE__         (0)
+#define MICROPY_PY_MICROPYTHON_MEM_INFO (0)
+#define MICROPY_PY_GC               (0)
+#define MICROPY_PY_GC_COLLECT_RETVAL (0)
+#define MICROPY_PY_ARRAY            (0)
+#define MICROPY_PY_COLLECTIONS      (0)
+#define MICROPY_PY_MATH             (0)
+#define MICROPY_PY_CMATH            (0)
+#define MICROPY_PY_IO               (0)
+#define MICROPY_PY_IO_FILEIO        (0)
+#define MICROPY_PY_STRUCT           (0)
+#define MICROPY_PY_SYS              (1)
+#define MICROPY_PY_SYS_EXIT         (0)
+#define MICROPY_PY_SYS_PLATFORM     "linux"
+#define MICROPY_PY_SYS_MAXSIZE      (0)
+#define MICROPY_PY_SYS_STDFILES     (0)
+#define MICROPY_PY_CMATH            (0)
+#define MICROPY_PY_UCTYPES          (0)
+#define MICROPY_PY_UZLIB            (0)
+#define MICROPY_PY_UJSON            (0)
+#define MICROPY_PY_URE              (0)
+#define MICROPY_PY_UHEAPQ           (0)
+#define MICROPY_PY_UHASHLIB         (0)
+#define MICROPY_PY_UBINASCII        (0)
+
+extern const struct _mp_obj_module_t mp_module_os;
+
+#define MICROPY_PORT_BUILTIN_MODULES \
+    { MP_ROM_QSTR(MP_QSTR_uos), MP_ROM_PTR(&mp_module_os) }, \
+
+#define MICROPY_PORT_ROOT_POINTERS \
+
+//////////////////////////////////////////
+// Do not change anything beyond this line
+//////////////////////////////////////////
+
+#if !(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || defined(__thumb2__) || defined(__thumb__) || defined(__arm__))
+// Fall back to setjmp() implementation for discovery of GC pointers in registers.
+#define MICROPY_GCREGS_SETJMP (1)
+#endif
+
+// type definitions for the specific machine
+
+#ifdef __LP64__
+typedef long mp_int_t; // must be pointer size
+typedef unsigned long mp_uint_t; // must be pointer size
+#else
+// These are definitions for machines where sizeof(int) == sizeof(void*),
+// regardless for actual size.
+typedef int mp_int_t; // must be pointer size
+typedef unsigned int mp_uint_t; // must be pointer size
+#endif
+
+// Cannot include <sys/types.h>, as it may lead to symbol name clashes
+#if _FILE_OFFSET_BITS == 64 && !defined(__LP64__)
+typedef long long mp_off_t;
+#else
+typedef long mp_off_t;
+#endif
+
+// We need to provide a declaration/definition of alloca()
+#ifdef __FreeBSD__
+#include <stdlib.h>
+#else
+#include <alloca.h>
+#endif

--- a/interpreter-manager/interpreterManager.h
+++ b/interpreter-manager/interpreterManager.h
@@ -1,6 +1,7 @@
 /*
 This file defines the class for the interpreter manager class.
 */
+#pragma once
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/lib/__main.c
+++ b/lib/__main.c
@@ -1,0 +1,267 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013, 2014 Damien P. George
+ * Copyright (c) 2014-2017 Paul Sokolovsky
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <errno.h>
+#include <signal.h>
+
+#include "py/compile.h"
+#include "py/runtime.h"
+#include "py/builtin.h"
+#include "py/repl.h"
+#include "py/gc.h"
+#include "py/stackctrl.h"
+#include "py/mphal.h"
+#include "py/mpthread.h"
+#include "extmod/misc.h"
+#include "extmod/vfs.h"
+#include "extmod/vfs_posix.h"
+// #include "genhdr/mpversion.h"
+#include "input.h"
+#include "py/objlist.h"
+
+// Command line options, with their defaults
+STATIC uint emit_opt = MP_EMIT_OPT_NONE;
+
+#if MICROPY_ENABLE_GC
+// Heap size of GC heap (if enabled)
+// Make it larger on a 64 bit machine, because pointers are larger.
+long heap_size = 1024 * 1024 * (sizeof(mp_uint_t) / 4);
+#endif
+
+STATIC void stderr_print_strn(void *env, const char *str, size_t len) {
+    (void)env;
+    ssize_t ret;
+    MP_HAL_RETRY_SYSCALL(ret, write(STDERR_FILENO, str, len), {});
+    mp_uos_dupterm_tx_strn(str, len);
+}
+
+const mp_print_t mp_stderr_print = {NULL, stderr_print_strn};
+
+#define FORCED_EXIT (0x100)
+// If exc is SystemExit, return value where FORCED_EXIT bit set,
+// and lower 8 bits are SystemExit value. For all other exceptions,
+// return 1.
+
+#define LEX_SRC_STR (1)
+#define LEX_SRC_VSTR (2)
+#define LEX_SRC_FILENAME (3)
+#define LEX_SRC_STDIN (4)
+
+// Returns standard error codes: 0 for success, 1 for all other errors,
+// except if FORCED_EXIT bit is set then script raised SystemExit and the
+// value of the exit is in the lower 8 bits of the return value
+
+#ifdef _WIN32
+#define PATHLIST_SEP_CHAR ';'
+#else
+#define PATHLIST_SEP_CHAR ':'
+#endif
+
+int main_();
+
+int __main() {
+    #if MICROPY_PY_THREAD
+    mp_thread_init();
+    #endif
+    // We should capture stack top ASAP after start, and it should be
+    // captured guaranteedly before any other stack variables are allocated.
+    // For this, actual main (renamed main_) should not be inlined into
+    // this function. main_() itself may have other functions inlined (with
+    // their own stack variables), that's why we need this main/main_ split.
+    mp_stack_ctrl_init();
+    return main_();
+}
+
+MP_NOINLINE int main_() {
+    #ifdef SIGPIPE
+    // Do not raise SIGPIPE, instead return EPIPE. Otherwise, e.g. writing
+    // to peer-closed socket will lead to sudden termination of MicroPython
+    // process. SIGPIPE is particularly nasty, because unix shell doesn't
+    // print anything for it, so the above looks like completely sudden and
+    // silent termination for unknown reason. Ignoring SIGPIPE is also what
+    // CPython does. Note that this may lead to problems using MicroPython
+    // scripts as pipe filters, but again, that's what CPython does. So,
+    // scripts which want to follow unix shell pipe semantics (where SIGPIPE
+    // means "pipe was requested to terminate, it's not an error"), should
+    // catch EPIPE themselves.
+    signal(SIGPIPE, SIG_IGN);
+    #endif
+
+    mp_stack_set_limit(40000 * (BYTES_PER_WORD / 4));
+
+    #if MICROPY_ENABLE_GC
+    char *heap = (char *)malloc(heap_size);
+    gc_init(heap, heap + heap_size);
+    #endif
+
+    #if MICROPY_ENABLE_PYSTACK
+    static mp_obj_t pystack[1024];
+    mp_pystack_init(pystack, &pystack[MP_ARRAY_SIZE(pystack)]);
+    #endif
+
+    mp_init();
+
+    #if MICROPY_EMIT_NATIVE
+    // Set default emitter options
+    MP_STATE_VM(default_emit_opt) = emit_opt;
+    #else
+    (void)emit_opt;
+    #endif
+
+    #if MICROPY_VFS_POSIX
+    {
+        // Mount the host FS at the root of our internal VFS
+        mp_obj_t args[2] = {
+            mp_type_vfs_posix.make_new(&mp_type_vfs_posix, 0, 0, NULL),
+            MP_OBJ_NEW_QSTR(MP_QSTR__slash_),
+        };
+        mp_vfs_mount(2, args, (mp_map_t *)&mp_const_empty_map);
+        MP_STATE_VM(vfs_cur) = MP_STATE_VM(vfs_mount_table);
+    }
+    #endif
+
+    char *home = getenv("HOME");
+    char *path = getenv("MICROPYPATH");
+    if (path == NULL) {
+        #ifdef MICROPY_PY_SYS_PATH_DEFAULT
+        path = MICROPY_PY_SYS_PATH_DEFAULT;
+        #endif
+    }
+    size_t path_num = 1; // [0] is for current dir (or base dir of the script)
+    if (*path == PATHLIST_SEP_CHAR) {
+        path_num++;
+    }
+    for (char *p = path; p != NULL; p = strchr(p, PATHLIST_SEP_CHAR)) {
+        path_num++;
+        if (p != NULL) {
+            p++;
+        }
+    }
+    mp_obj_list_init((mp_obj_list_t *)MP_OBJ_TO_PTR(mp_sys_path), path_num);
+    mp_obj_t *path_items;
+    mp_obj_list_get(mp_sys_path, &path_num, &path_items);
+    path_items[0] = MP_OBJ_NEW_QSTR(MP_QSTR_);
+    {
+        char *p = path;
+        for (mp_uint_t i = 1; i < path_num; i++) {
+            char *p1 = strchr(p, PATHLIST_SEP_CHAR);
+            if (p1 == NULL) {
+                p1 = p + strlen(p);
+            }
+            if (p[0] == '~' && p[1] == '/' && home != NULL) {
+                // Expand standalone ~ to $HOME
+                int home_l = strlen(home);
+                vstr_t vstr;
+                vstr_init(&vstr, home_l + (p1 - p - 1) + 1);
+                vstr_add_strn(&vstr, home, home_l);
+                vstr_add_strn(&vstr, p + 1, p1 - p - 1);
+                path_items[i] = mp_obj_new_str_from_vstr(&mp_type_str, &vstr);
+            } else {
+                path_items[i] = mp_obj_new_str_via_qstr(p, p1 - p);
+            }
+            p = p1 + 1;
+        }
+    }
+
+    mp_obj_list_init(MP_OBJ_TO_PTR(mp_sys_argv), 0);
+
+    #if defined(MICROPY_UNIX_COVERAGE)
+    {
+        MP_DECLARE_CONST_FUN_OBJ_0(extra_coverage_obj);
+        mp_store_global(QSTR_FROM_STR_STATIC("extra_coverage"), MP_OBJ_FROM_PTR(&extra_coverage_obj));
+    }
+    #endif
+
+    // Here is some example code to create a class and instance of that class.
+    // First is the Python, then the C code.
+    //
+    // class TestClass:
+    //     pass
+    // test_obj = TestClass()
+    // test_obj.attr = 42
+    //
+    // mp_obj_t test_class_type, test_class_instance;
+    // test_class_type = mp_obj_new_type(QSTR_FROM_STR_STATIC("TestClass"), mp_const_empty_tuple, mp_obj_new_dict(0));
+    // mp_store_name(QSTR_FROM_STR_STATIC("test_obj"), test_class_instance = mp_call_function_0(test_class_type));
+    // mp_store_attr(test_class_instance, QSTR_FROM_STR_STATIC("attr"), mp_obj_new_int(42));
+
+    /*
+    printf("bytes:\n");
+    printf("    total %d\n", m_get_total_bytes_allocated());
+    printf("    cur   %d\n", m_get_current_bytes_allocated());
+    printf("    peak  %d\n", m_get_peak_bytes_allocated());
+    */
+    return 0;
+}
+
+
+#if MICROPY_PY_IO
+// Factory function for I/O stream classes, only needed if generic VFS subsystem isn't used.
+// Note: buffering and encoding are currently ignored.
+mp_obj_t mp_builtin_open(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kwargs) {
+    enum { ARG_file, ARG_mode };
+    STATIC const mp_arg_t allowed_args[] = {
+        { MP_QSTR_file, MP_ARG_OBJ | MP_ARG_REQUIRED, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_mode, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_QSTR(MP_QSTR_r)} },
+        { MP_QSTR_buffering, MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_encoding, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kwargs, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+    return mp_vfs_posix_file_open(&mp_type_textio, args[ARG_file].u_obj, args[ARG_mode].u_obj);
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
+#endif
+
+void nlr_jump_fail(void *val) {
+    fprintf(stderr, "FATAL: uncaught NLR %p\n", val);
+    exit(1);
+}
+
+#if !MICROPY_VFS
+uint mp_import_stat(const char *path) {
+    struct stat st;
+    if (stat(path, &st) == 0) {
+        if (S_ISDIR(st.st_mode)) {
+            return MP_IMPORT_STAT_DIR;
+        } else if (S_ISREG(st.st_mode)) {
+            return MP_IMPORT_STAT_FILE;
+        }
+    }
+    return MP_IMPORT_STAT_NO_EXIST;
+}
+#endif


### PR DESCRIPTION
# Summary

The current micropython interpreter did not have sys functionality, an essential python package. This current fix adds this functionality to our interpreter manager. 

# Build

To build the file run `make` in the `upytorch /cpp_torch_examples` folder. 